### PR TITLE
[Industrial Revolution 2] Fix "steel-cleaner" Incompatibility

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -58,6 +58,16 @@ exclusions =
 		}
 	},
 
+	{  -- Industrial Revolution 2
+		apply_when_object_exists = {
+			type = "assembling-machine",
+			name = "steel-cleaner"
+		},
+		excluded_prototype_names = {
+			"steel-cleaner"
+		}
+	},
+
 	{  -- UraniumPower mod    (some test-entities display errors if altered so are excluded below)
 		apply_when_object_exists = {
 			type = "storage-tank",


### PR DESCRIPTION
Fix for following error with IR2 by excluding entity prototype "steel-cleaner" from bounding box adjustments

`Error while entity prototype "steel-cleaner" (assembling-machine): Invalid pipe connections specification for offset {0.0000000000,-1.2500000000}. The offset must be outside of the entity bounding-box
Modifications: Industrial Revolution 2 > Spueak Through > Industrial Revolutuion 2`

https://mods.factorio.com/mod/Squeak%20Through/discussion/5fe8752b8a83b2fbf8d91d84